### PR TITLE
Update mysql-export.sh

### DIFF
--- a/mysql-export.sh
+++ b/mysql-export.sh
@@ -133,7 +133,7 @@ fi
 MKTEMP=/bin/tempfile
 if [ ! -x $MKTEMP ]; then
     MKTEMP=`which mktemp`
-    result=$($MKTEMP "$TMP_FOLDER/phpmyadmin_export.XXXXXX.tmp")
+    result=$($MKTEMP "$TMP_FOLDER/phpmyadmin_export.XXXXXX")
 else
     result=$($MKTEMP "$TMP_FOLDER/phpmyadmin_export.$RANDOM.tmp")
 fi


### PR DESCRIPTION
The mktemp command requires the XXXXXX template to be the end of the file name.  So phpmyadmin_export.XXXXXX.tmp doesn't work, it needs to be phpymadmin_export.XXXXXX instead.